### PR TITLE
[PR-1] - Create workflow for enforcing 80% test coverage

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,0 +1,35 @@
+name: Go Test Coverage
+
+on:
+  push:
+    branches: [development, master]
+  pull_request:
+    branches: [development, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.24'
+
+      - name: Run Tests and Generate Coverage Report
+        run: |
+          go test -coverprofile=coverage.out ./...
+          # Display total coverage
+          go tool cover -func=coverage.out | grep total
+
+      - name: Ensure Minimum 80% Coverage
+        run: |
+          coverage=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+          echo "Current coverage: $coverage%"
+          # If the coverage is below 80%, the build fails
+          if (( $(echo "$coverage < 80" | bc -l) )); then
+            echo "Coverage below 80%!"
+            exit 1
+          fi


### PR DESCRIPTION
ci: add GitHub Actions workflow for enforcing 80% test coverage

This commit introduces a workflow that runs on push and pull_request events for both development and master branches. It sets up Go, runs tests, generates a coverage report, and fails the build if the coverage falls below 80%.